### PR TITLE
Bug: New product does not show up in new arrivals

### DIFF
--- a/blocknewproducts.php
+++ b/blocknewproducts.php
@@ -305,7 +305,7 @@ class BlockNewProducts extends Module
         ];
 
         foreach ($caches as $template => $cacheId) {
-            Tools::clearCache(Context::getContext()->smarty, $template, $cacheId);
+            Tools::clearCache(Context::getContext()->smarty, $this->getTemplatePath($template), $cacheId);
         }
 
         Configuration::updateValue(static::CACHE_TIMESTAMP, time());


### PR DESCRIPTION
There's a bug in cache clearing logic, reported in this [topic](https://forum.thirtybees.com/topic/1748/new-product-does-not-show-up-in-new-arrivals-new-products-block-on-home-page-when-caching-is-on-tb-1-0-4) on forum.